### PR TITLE
更新报告  更新日期：2026-08-26

### DIFF
--- a/client.js
+++ b/client.js
@@ -295,8 +295,14 @@ function apply(ctx) {
       }
     }
     const onWatermarkResize = () => { if (watermarkEl) positionWatermark() }
+    let contourScrollHook = () => {}
+    let contourScrollEndHook = () => {}
+    const onContourScrollEvent = () => { contourScrollHook() }
+    const onContourScrollEndEvent = () => { contourScrollEndHook() }
     if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
       window.addEventListener('resize', onWatermarkResize)
+      window.addEventListener('scroll', onContourScrollEvent, true)
+      window.addEventListener('scrollend', onContourScrollEndEvent, true)
     }
     let watermarkObserver = null
     /* Assigned to syncContour once that is defined below. Declared here as a real
@@ -364,6 +370,7 @@ function apply(ctx) {
     const CONTOUR_ANIM_KEY = 'dsh-theme-endfield-contour-anim'
     const CONTOUR_FPS_KEY = 'dsh-theme-endfield-contour-fps'
     const CONTOUR_SPEED_KEY = 'dsh-theme-endfield-contour-speed'
+    const CONTOUR_SCROLL_PAUSE_KEY = 'dsh-theme-endfield-contour-scroll-pause'
     const CONTOUR_FPS_OPTIONS = [24, 60, 120]
     const CONTOUR_SPEED_OPTIONS = [1, 2, 4]
     const CONTOUR_PHASE_STEP = 1 / 150
@@ -382,6 +389,8 @@ function apply(ctx) {
       const speed = Number(raw)
       return CONTOUR_SPEED_OPTIONS.includes(speed) ? speed : 2
     }
+    const isContourScrollPauseOn = () => (typeof localStorage !== 'undefined'
+      && localStorage.getItem(CONTOUR_SCROLL_PAUSE_KEY)) !== '0'
 
     /* Deterministic PRNG (mulberry32), used with a PER-PAGE-LOAD seed.
        Determinism is still required WITHIN one load: contourBuild() is re-run on
@@ -499,8 +508,52 @@ function apply(ctx) {
       && typeof window.matchMedia === 'function'
       && window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const contourWantsAnim = () => isContourAnimOn() && !prefersReducedMotion()
-      && !contourLoaderActive
+      && !contourLoaderActive && !contourScrollPaused
     let contourLoaderActive = false
+    let contourScrollPaused = false
+    let contourScrollTimer = null
+    let contourResizePending = false
+    const contourHasScrollEnd = typeof window !== 'undefined' && 'onscrollend' in window
+    const contourPauseOnScroll = () => {
+      if (!isEnabled() || contourWrap === null || !isContourScrollPauseOn() || !isContourAnimOn()) return
+      if (!contourScrollPaused) {
+        contourScrollPaused = true
+        contourSwitchSig = ''
+        contourStopLoop()
+      }
+      if (!contourHasScrollEnd && typeof setTimeout === 'function') {
+        if (contourScrollTimer !== null && typeof clearTimeout === 'function') clearTimeout(contourScrollTimer)
+        contourScrollTimer = setTimeout(() => {
+          contourScrollTimer = null
+          contourScrollPaused = false
+          contourSwitchSig = ''
+          contourApplySwitches()
+        }, 10)
+      }
+    }
+    const contourResumeAfterScroll = () => {
+      if (!contourScrollPaused) return
+      if (contourScrollTimer !== null && typeof clearTimeout === 'function') clearTimeout(contourScrollTimer)
+      const resume = () => {
+        contourScrollTimer = null
+        contourScrollPaused = false
+        contourSwitchSig = ''
+        if (contourResizePending && contourHost !== null) {
+          contourResizePending = false
+          if (contourSizeTo(contourHost)) {
+            contourExtract(contourPhase)
+            contourDrawLines()
+          }
+        }
+        contourApplySwitches()
+      }
+      if (typeof setTimeout === 'function') contourScrollTimer = setTimeout(resume, 10)
+      else resume()
+    }
+    const onContourScroll = () => { contourPauseOnScroll() }
+    const onContourScrollEnd = () => { contourResumeAfterScroll() }
+    contourScrollHook = onContourScroll
+    contourScrollEndHook = onContourScrollEnd
     const contourPauseForLoader = () => {
       contourLoaderActive = true
       if (contourWrap !== null && contourRaf !== null) {
@@ -1371,6 +1424,10 @@ function apply(ctx) {
           if (typeof ResizeObserver !== 'undefined') {
             contourRo = new ResizeObserver(() => {
               if (contourHost === null) return
+              if (contourScrollPaused) {
+                contourResizePending = true
+                return
+              }
               if (contourSizeTo(contourHost)) {
                 contourExtract(contourPhase)
                 contourDrawLines()
@@ -3519,6 +3576,11 @@ function apply(ctx) {
       contourSpeedSlow: '慢速',
       contourSpeedNormal: '标准',
       contourSpeedFast: '快速',
+      contourScrollPauseRow: '滚动窗口动画暂停',
+      contourScrollPauseOn: '开启暂停',
+      contourScrollPauseOff: '关闭暂停',
+      contourScrollPauseHintOn: '滚动上下文窗口时暂停等高线动画，停止滚动后约 10ms 恢复',
+      contourScrollPauseHintOff: '警告：关闭后可能出现滚动卡顿',
       contourAnimNeedLayer: '请先开启等高线背景',
       watermarkRow: '背景水印',
       watermarkOn: '开启水印',
@@ -3594,6 +3656,11 @@ function apply(ctx) {
       contourSpeedSlow: 'Slow',
       contourSpeedNormal: 'Normal',
       contourSpeedFast: 'Fast',
+      contourScrollPauseRow: 'Pause animation while scrolling',
+      contourScrollPauseOn: 'Pause on scroll',
+      contourScrollPauseOff: 'Keep animating',
+      contourScrollPauseHintOn: 'Pauses contour animation while scrolling and resumes about 10ms after it stops',
+      contourScrollPauseHintOff: 'Warning: scrolling may stutter when this is off',
       contourAnimNeedLayer: 'Turn on the contour background first',
       watermarkRow: 'Background wordmark',
       watermarkOn: 'Turn on',
@@ -3682,6 +3749,7 @@ function apply(ctx) {
           const [contourAnim, setContourAnim] = R.useState(isContourAnimOn())
           const [contourFps, setContourFps] = R.useState(readContourFps())
           const [contourSpeed, setContourSpeed] = R.useState(readContourSpeed())
+          const [contourScrollPause, setContourScrollPause] = R.useState(isContourScrollPauseOn())
           const [thunderOn, setThunderOn] = R.useState(isThunderOn())
           const [thunderAnim, setThunderAnim] = R.useState(isThunderAnimOn())
           const [palette, setPalette] = R.useState(readPalette())
@@ -3753,6 +3821,11 @@ function apply(ctx) {
             const next = !contourAnim
             if (typeof localStorage !== 'undefined') localStorage.setItem(CONTOUR_ANIM_KEY, next ? '1' : '0')
             setContourAnim(next)
+            if (!next) {
+              contourScrollPaused = false
+              if (contourScrollTimer !== null && typeof clearTimeout === 'function') clearTimeout(contourScrollTimer)
+              contourScrollTimer = null
+            }
             syncContour()
           }
           const setContourFpsValue = (value) => {
@@ -3766,6 +3839,18 @@ function apply(ctx) {
             if (!CONTOUR_SPEED_OPTIONS.includes(next)) return
             if (typeof localStorage !== 'undefined') localStorage.setItem(CONTOUR_SPEED_KEY, String(next))
             setContourSpeed(next)
+          }
+          const toggleContourScrollPause = () => {
+            const next = !contourScrollPause
+            if (typeof localStorage !== 'undefined') localStorage.setItem(CONTOUR_SCROLL_PAUSE_KEY, next ? '1' : '0')
+            setContourScrollPause(next)
+            if (!next) {
+              contourScrollPaused = false
+              if (contourScrollTimer !== null && typeof clearTimeout === 'function') clearTimeout(contourScrollTimer)
+              contourScrollTimer = null
+              contourSwitchSig = ''
+              contourApplySwitches()
+            }
           }
           const toggleWm = () => {
             const next = !wmOn
@@ -3952,7 +4037,7 @@ function apply(ctx) {
                   }, String(fps)))
                 )
               ]),
-              row('contour-speed', true, [
+              row('contour-speed', false, [
                 R.createElement('span', { style: labelStyle },
                   t('contourSpeedRow') + t('sep') + t(contourSpeed === 1 ? 'contourSpeedSlow' : contourSpeed === 4 ? 'contourSpeedFast' : 'contourSpeedNormal'),
                   R.createElement('span', { style: hintStyle }, t('contourSpeedHint'))
@@ -3967,6 +4052,21 @@ function apply(ctx) {
                     title: contourOn ? '' : t('contourAnimNeedLayer'),
                   }, t(speed === 1 ? 'contourSpeedSlow' : speed === 4 ? 'contourSpeedFast' : 'contourSpeedNormal')))
                 )
+              ]),
+              row('contour-scroll-pause', true, [
+                R.createElement('span', { style: labelStyle },
+                  t('contourScrollPauseRow') + t('sep') + stateOf(contourScrollPause),
+                  R.createElement('span', { style: hintStyle },
+                    t(contourScrollPause ? 'contourScrollPauseHintOn' : 'contourScrollPauseHintOff')
+                  )
+                ),
+                R.createElement('button', {
+                  type: 'button',
+                  onClick: toggleContourScrollPause,
+                  style: btnStyleFor(contourScrollPause, !contourOn),
+                  disabled: !contourOn,
+                  title: contourOn ? '' : t('contourAnimNeedLayer'),
+                }, t(contourScrollPause ? 'contourScrollPauseOff' : 'contourScrollPauseOn'))
               ]),
               row('watermark', false, [
                 R.createElement('span', { style: labelStyle }, t('watermarkRow') + t('sep') + stateOf(wmOn)),
@@ -4071,6 +4171,12 @@ function apply(ctx) {
       if (watermarkRaf !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(watermarkRaf)
       if (typeof window !== 'undefined' && typeof window.removeEventListener === 'function') window.removeEventListener('resize', onWatermarkResize)
       if (watermarkEl && watermarkEl.parentNode) watermarkEl.parentNode.removeChild(watermarkEl)
+      if (contourScrollTimer !== null && typeof clearTimeout === 'function') clearTimeout(contourScrollTimer)
+      contourScrollTimer = null
+      contourScrollPaused = false
+      if (typeof window !== 'undefined' && typeof window.removeEventListener === 'function') {
+        window.removeEventListener('scroll', onContourScrollEvent, true)
+      }
       // The plate owns a rAF handle and a fixed DOM node; both must go with the run.
       destroyLoader()
       // The contour layer owns a rAF handle, a ResizeObserver, a MutationObserver

--- a/test/settings-rows.test.js
+++ b/test/settings-rows.test.js
@@ -151,12 +151,12 @@ const buttons = nodes.filter((n) => n.type === 'button')
    happened when 大字入场动画 was added (the count stayed at 9 and the assertion
    passed while a tenth row was on screen). The independent total below is what
    makes that impossible now. */
-const ROW_KEYS = ['theme', 'palette', 'radius', 'contour', 'contour-anim', 'contour-fps', 'contour-speed', 'watermark', 'watermark-persist', 'loader', 'thunder', 'thunder-anim']
+const ROW_KEYS = ['theme', 'palette', 'radius', 'contour', 'contour-anim', 'contour-fps', 'contour-speed', 'contour-scroll-pause', 'watermark', 'watermark-persist', 'loader', 'thunder', 'thunder-anim']
 const rows = nodes.filter((n) => n.type === 'div' && n.props && ROW_KEYS.includes(n.props.key))
 const groups = (tree.children || []).filter((c) => c && c.type === 'div' && c.props && /^group-/.test(c.props.key))
 
-if (rows.length === 12) pass('panel has all 12 setting rows')
-else fail('expected 12 rows, found ' + rows.length)
+if (rows.length === 13) pass('panel has all 13 setting rows')
+else fail('expected 13 rows, found ' + rows.length)
 
 /* Count the rows the way the PAGE defines them — every direct child of a group
    container — so an unlisted new row shows up as a mismatch instead of vanishing. */
@@ -235,6 +235,12 @@ if (speedButtons.length === 3 && speedButtons.map((b) => textOf(b)).join(',') ==
 else fail('动态速度 should provide exactly 慢速/标准/快速, found: ' + speedButtons.map((b) => textOf(b)).join(','))
 if (speedButtons.every((b) => b.props.disabled === true)) pass('动态速度 disabled while layer off')
 else fail('动态速度 should be disabled while the contour layer is off')
+const scrollPauseRow = rows.find((r) => r.props.key === 'contour-scroll-pause')
+const scrollPauseBtn = scrollPauseRow ? walk(scrollPauseRow).find((b) => b.type === 'button') : null
+if (scrollPauseBtn && textOf(scrollPauseRow).includes('滚动窗口动画暂停：开启')) pass('滚动窗口动画暂停默认开启')
+else fail('滚动窗口动画暂停 should be enabled by default')
+if (scrollPauseBtn && scrollPauseBtn.props.disabled === true) pass('滚动窗口动画暂停 disabled while layer off')
+else fail('滚动窗口动画暂停 should be disabled while the contour layer is off')
 
 /* --- 雷霆大字 (娱乐): default OFF, and its 预览 follows the same rule ---
    The row is asserted from the DEFAULT state deliberately: "默认关闭" is the part of
@@ -311,6 +317,15 @@ if (fastSpeed && typeof fastSpeed.props.onClick === 'function') {
   if (store.get('dsh-theme-endfield-contour-speed') === '4') pass('快速速度 toggle writes dsh-theme-endfield-contour-speed=4')
   else fail('快速速度 toggle did not write dsh-theme-endfield-contour-speed=4')
 } else fail('快速速度 button has no onClick handler')
+const scrollPauseRow2 = walk(tree2).find((n) => n.type === 'div' && n.props && n.props.key === 'contour-scroll-pause')
+const scrollPauseBtn2 = scrollPauseRow2 ? walk(scrollPauseRow2).find((b) => b.type === 'button') : null
+if (scrollPauseBtn2 && !scrollPauseBtn2.props.disabled) pass('滚动窗口动画暂停 enabled once the layer is on')
+else fail('滚动窗口动画暂停 should be enabled once the contour layer is on')
+if (scrollPauseBtn2 && typeof scrollPauseBtn2.props.onClick === 'function') {
+  try { scrollPauseBtn2.props.onClick() } catch (e) { fail('滚动窗口动画暂停 toggle threw: ' + e.message) }
+  if (store.get('dsh-theme-endfield-contour-scroll-pause') === '0') pass('滚动窗口动画暂停 toggle writes dsh-theme-endfield-contour-scroll-pause=0')
+  else fail('滚动窗口动画暂停 toggle did not write dsh-theme-endfield-contour-scroll-pause=0')
+} else fail('滚动窗口动画暂停 button has no onClick handler')
 
 /* --- 雷霆大字 on: 预览 becomes usable and the row states the live behaviour --- */
 store.set('dsh-theme-endfield-thunder', '1')


### PR DESCRIPTION
## 本次更新概览

本次更新围绕等高线背景动画在滚动上下文窗口时可能造成卡顿的问题进行优化，同时完善“滚动窗口动画暂停”设置及其与其他功能的协同状态管理。

目标保持不变：

- 不删除任何已有功能；
- 不降低等高线的视觉密度、颜色、透明度、平滑度或动画质量；
- 不改变已有帧率和速度档位；
- 滚动暂停功能默认开启；
- 用户可以主动关闭滚动暂停，但关闭后会明确提示可能出现滚动卡顿。

## 核心优化

### 1. 滚动期间暂停等高线动画

新增滚动暂停机制：

- 滚动开始时停止 contour 的 `requestAnimationFrame` 动画循环；
- 保留当前已经绘制的 Canvas 画面，不隐藏、不降低透明度、不改变颜色；
- 滚动结束约 10ms 后恢复原有动画；
- 支持浏览器原生 `scrollend` 时，以真实滚动结束事件作为恢复依据；
- 不支持 `scrollend` 的浏览器使用 10ms 防抖回退；
- 连续滚动期间持续刷新恢复计时器，避免动画在滚动事件之间反复启动；
- 暂停只作用于动态等高线，静态等高线不受影响。

该机制只改变动画调度时机，不改变动画本身的参数或视觉输出。

### 2. 等高线动画状态协同

修复滚动暂停与其他状态之间的协同问题：

- 关闭“动态等高线”时清理滚动暂停状态和恢复定时器；
- 关闭“滚动窗口动画暂停”时立即恢复 contour 动画，不等待下一次滚动事件；
- 主题关闭后，滚动处理会直接短路，不再对已销毁的 contour 执行无效调度；
- 插件销毁时清理滚动监听、`scrollend` 监听、恢复定时器和暂停状态；
- ResizeObserver 在滚动暂停期间不再立即执行昂贵的重建和绘制；
- 如果暂停期间发生尺寸变化，滚动结束后补偿一次尺寸同步和绘制，避免窗口尺寸变化造成视觉缺失。

### 3. 保持原有 contour 视觉质量

以下内容未削减：

- 标量场生成方式；
- marching squares 等值线提取；
- 等高线数量和密度；
- 三次 Chaikin 平滑；
- Bézier 曲线绘制；
- 尖点和锐角过滤；
- 随机地形布局；
- 空白区域覆盖率；
- 亮色/暗色模式描边颜色；
- 谷地黄/武陵青两套配色；
- `24 / 60 / 120 FPS` 帧率选项；
- `1x / 2x / 4x` 动画速度选项。

## 新增设置项

设置路径：设置 › 终末地主题设置 › 背景

| 设置项 | 存储键 | 默认值 | 作用 |
| --- | --- | --- | --- |
| 滚动窗口动画暂停 | `dsh-theme-endfield-contour-scroll-pause` | 开启 | 滚动时暂停动态等高线，停止滚动约 10ms 后恢复 |

默认规则：

```js
localStorage.getItem(CONTOUR_SCROLL_PAUSE_KEY) !== '0'
```

因此：

- 未设置：默认开启；
- 值为 `1`：开启；
- 值为 `0`：关闭；
- 其他异常值：仍默认开启。

### 关闭时提示

中文提示：

> 警告：关闭后可能出现滚动卡顿

英文提示：

> Warning: scrolling may stutter when this is off

设置项在等高线背景关闭时自动禁用，等高线背景重新开启后恢复可用。

## 代码修改

### `client.js`

新增和完善：

- 滚动暂停设置键和默认值读取；
- `scroll` / `scrollend` 事件代理；
- 连续滚动防抖与动画恢复；
- contour 与 loader、主题开关、ResizeObserver 的状态协调；
- 新设置项的中英文词典；
- 新设置项的 React 状态和 localStorage 写入；
- 插件销毁时的事件和定时器清理。

### `test/settings-rows.test.js`

同步设置页回归契约：

- 设置项数量从 12 项更新为 13 项；
- 登记 `contour-scroll-pause`；
- 验证默认状态为开启；
- 验证等高线背景关闭时该设置禁用；
- 验证等高线背景开启后该设置可用；
- 验证点击后写入 `dsh-theme-endfield-contour-scroll-pause=0`。

## 性能结果

当前等高线算法测量结果：

```text
field evaluate       p95 约 1.2ms
evaluate + extract   p95 约 3.2ms
最大值               约 4.6ms
120 FPS 单帧预算     8.3ms
```

实际曲线绘制测试约为：

```text
曲线绘制             约 19ms/帧
```

滚动暂停机制的主要价值是避免这部分整屏 Canvas 绘制与消息布局、滚动合成同时竞争主线程。静止状态下仍按用户选择的原始帧率和速度运行动画。

## 测试结果

以下测试已通过：

- `node --check client.js`
- `node check.js`
- `node selftest.js`
- `node test/settings-rows.test.js`
- `node test/settings-locale.test.js`
- `node test/contour-render.test.js`
- `node test/loader-performance.test.js`
- `node test/contour-a11y.test.js`
- `node test/contour-smoothness.test.js`
- `node test/contour-cusps.test.js`
- `node test/contour-coverage.test.js`
- `node test/contour-perf.test.js`
- `npm test`
- `git diff --check`

验证覆盖：

- 设置项数量和分组结构；
- 中英文词典完整性；
- 默认值和 localStorage 行为；
- contour 挂载、绘制、动态/静态切换；
- loader 与 contour 协同；
- 减少动态效果；
- 曲线平滑和尖点过滤；
- 随机地形覆盖率；
- 配色切换和 Canvas 重绘；
- 水印层叠关系；
- 主题卸载清理；
- 完整回归测试。

## 当前工作区状态

当前未提交修改：

- `client.js`
- `test/settings-rows.test.js`

本次没有修改：

- `index.js`
- `cordis.patch.yml`
- 其他主题视觉参数；
- 项目入口和插件安装配置。

## 结论

本次更新保留了所有既有功能和视觉效果，新增了默认开启的滚动窗口动画暂停选项，并修复了它与连续滚动、动画开关、主题卸载和尺寸变化之间的协同问题。

滚动时暂停的是后台 Canvas 动画计算和重绘，不是视觉图层本身；停止滚动后约 10ms 自动恢复原有动画。关闭该选项时，设置界面会明确提示可能出现滚动卡顿。