### PR TITLE
fix(test): 固定 hover-check 的字体栅格化，修跨平台假失败

### DIFF
--- a/test/hover-check.js
+++ b/test/hover-check.js
@@ -198,8 +198,19 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
   </script></body></html>`)
 
   const port = 9333 + Math.floor(Math.random() * 400)
+  /* Font-rendering flags pin the glyph rasteriser across platforms. Without them
+     this check passes on Windows and fails on Linux: the ink sample below picks
+     "the pixel furthest in luminance from the fill that occurs >= 3 times", and
+     that needs enough SOLID stroke pixels to clear the threshold. Windows
+     (DirectWrite) leaves plenty; Linux (FreeType) with hinting + LCD subpixel AA
+     smears the same glyphs into mostly-blended pixels, so the sample lands on an
+     anti-aliased edge — a ~50% mix of ink and fill — and the measured contrast
+     collapses (3.85:1 on 谷地黄, 3.33:1 on 武陵青) even though the palette itself
+     never changed. Greyscale AA with hinting off keeps the stroke cores solid. */
   const proc = spawn(chrome, ['--headless=new', '--disable-gpu', '--no-sandbox',
     '--hide-scrollbars', '--window-size=520,220',
+    '--font-render-hinting=none', '--disable-font-subpixel-positioning',
+    '--disable-lcd-text', '--force-color-profile=srgb',
     '--remote-debugging-port=' + port,
     '--user-data-dir=' + fs.mkdtempSync(path.join(os.tmpdir(), 'hover-prof-')),
     'file:///' + page.replace(/\\/g, '/')], { stdio: ['ignore', 'ignore', 'ignore'] })


### PR DESCRIPTION
CI 首次运行（run 32986946427）18/19 通过，唯一失败是 `test/hover-check.js` 的四个「真实 :hover」断言。这个 PR 修它。

## 不是可访问性缺陷

失败报的是对比度不足（谷地黄 3.85:1、武陵青 3.33:1，阈值 4.5），但配色一行没改。三条证据指向测试本身：

1. 报告的 `ink=rgb(128, 123, 8)` 压在 `fill=rgb(255, 245, 0)` 上——这个值约是文字色与黄底的 50% 混合，是**抗锯齿边缘像素**，不是主题定义的任何文字色。
2. 同一套配色的 `palette-contrast.test.js` 和 `settings-buttons.test.js`（33 个断言）在同一次 CI 里**全绿**。那两个查的是 CSS 计算值，不采样渲染像素。
3. 失败只出现在 Linux，Windows 上一直通过。

## 根因

ink 采样这样选「字形核心」：

```js
// Ink = the pixel furthest in luminance from the fill (the glyph core).
for (const [k, n] of sorted) {
  if (n < 3) continue        // 出现 >= 3 次的像素才算
```

这需要足够多的**实心笔画像素**越过 `n >= 3` 门槛。Windows 的 DirectWrite 会留下很多；Linux 的 FreeType 带 hinting + LCD 亚像素抗锯齿，把同样字号的字形抹成大部分是混合像素，于是「亮度距填充色最远且出现 ≥3 次」的那个落在了抗锯齿边缘上，对比度随之塌掉。

测试隐含依赖了字体栅格化行为，而那个行为跨平台不一致。

## 改动

给 Chrome 加四个参数把栅格化钉死：

| 参数 | 作用 |
| --- | --- |
| `--font-render-hinting=none` | 关 hinting |
| `--disable-font-subpixel-positioning` | 关亚像素定位 |
| `--disable-lcd-text` | 用灰度抗锯齿代替 LCD 亚像素 |
| `--force-color-profile=srgb` | 统一色彩配置 |

笔画核心因此保持实心，采样不再落到边缘。断言逻辑和 4.5:1 阈值都没动——可访问性门槛未被削弱。

## Windows 实测

采样点从混合边缘移到了实心笔画，这本身就是诊断的验证：

| | ink 采样值 | 谷地黄 | 武陵青 |
| --- | --- | --- | --- |
| CI（无参数） | `rgb(128, 123, 8)` 混合边缘 | 3.85:1 ❌ | 3.33:1 ❌ |
| 加参数后 | `rgb(26, 27, 15)` 实心笔画 | **15.16:1** ✅ | **9.35:1** ✅ |

余量从「差 0.65」变成「超 10.6」。

Linux 上的效果由这个 PR 的 CI 运行验证——这也是工作流合并后第一次真正的「新 PR 触发检查」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)